### PR TITLE
Commerce Marketplace Integration

### DIFF
--- a/commerce_stripe.api.php
+++ b/commerce_stripe.api.php
@@ -10,6 +10,16 @@
  *  $context['payment_method'] is the enabled payment method, included for reference.
  *
  */
-function hook_commerce_stripe_transaction_alter(&$charge, &$transaction) {
+function hook_commerce_stripe_charge_alter(&$charge, &$transaction) {
+// No example.
+}
+
+/**
+ *
+ * Modify the transaction before it's passed to commerce_payment_transaction_save.
+ * @param $transaction The transaction object to be modified.
+ * @param $response The response object from Stripe, for reference.
+ */
+function hook_commerce_stripe_transaction_alter(&$transaction, $response) {
 // No example.
 }

--- a/commerce_stripe.api.php
+++ b/commerce_stripe.api.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @param $charge
+ * This is the charge object which will be handed to Stripe_Charge::create().
+ * You can modify it according to the docs here: https://stripe.com/docs/api/php#charges
+ *
+ * @param $transaction
+ * This is the transaction created by commerce_payment_transaction_new which will be saved by commerce_payment_transaction_save
+ *
+ */
+function hook_commerce_stripe_transaction_alter($charge, $transaction) {
+// No example.
+}

--- a/commerce_stripe.api.php
+++ b/commerce_stripe.api.php
@@ -1,14 +1,15 @@
 <?php
-
 /**
+ *
  * @param $charge
  * This is the charge object which will be handed to Stripe_Charge::create().
  * You can modify it according to the docs here: https://stripe.com/docs/api/php#charges
- *
- * @param $transaction
- * This is the transaction created by commerce_payment_transaction_new which will be saved by commerce_payment_transaction_save
+ * @param $context is an array of variables, the context of the charge, including:
+ *  $context['dest'] will be handed as the second paramenter to Stripe_Charge::create()
+ *  $context['transaction'] is the transation object being created, for reference.
+ *  $context['payment_method'] is the enabled payment method, included for reference.
  *
  */
-function hook_commerce_stripe_transaction_alter($charge, $transaction) {
+function hook_commerce_stripe_transaction_alter(&$charge, &$transaction) {
 // No example.
 }

--- a/commerce_stripe.js
+++ b/commerce_stripe.js
@@ -9,6 +9,11 @@
       if (settings.stripe.fetched == null) {
         settings.stripe.fetched = true;
 
+        var commercePaymentDom = 'commerce-payment';
+        if ($('form#commerce-checkout-form-review fieldset').length > 0) {
+            commercePaymentDom = 'commerce-marketplace-payment';
+        }
+
         var createToken = function (cardFieldMap, responseHandler) {
           Stripe.setPublishableKey(settings.stripe.publicKey);
 
@@ -72,7 +77,7 @@
           // Prevent the Stripe actions to be triggered if Stripe is not selected.
           if ($("input[value*='commerce_stripe|']").is(':checked')) {
             // Do not fetch the token if cardonfile is enabled and the customer has selected an existing card.
-            if ($('.form-item-commerce-payment-payment-details-cardonfile').length) {
+            if ($('.form-item-' + commercePaymentDom + '-payment-details-cardonfile').length) {
               // If select list enabled in card on file settings
               if ($("select[name='commerce_payment[payment_details][cardonfile]']").length
                   && $("select[name='commerce_payment[payment_details][cardonfile]'] option:selected").val() != 'new') {
@@ -105,11 +110,11 @@
             $('.form-submit').attr("disabled", "disabled");
 
             var cardFields = {
-              number: 'edit-commerce-payment-payment-details-credit-card-number',
-              cvc: 'edit-commerce-payment-payment-details-credit-card-code',
-              exp_month: 'edit-commerce-payment-payment-details-credit-card-exp-month',
-              exp_year: 'edit-commerce-payment-payment-details-credit-card-exp-year',
-              name: 'edit-commerce-payment-payment-details-credit-card-owner'
+              number: 'edit-' + commercePaymentDom + '-payment-details-credit-card-number',
+              cvc: 'edit-' + commercePaymentDom + '-payment-details-credit-card-code',
+              exp_month: 'edit-' + commercePaymentDom + '-payment-details-credit-card-exp-month',
+              exp_year: 'edit-' + commercePaymentDom + '-payment-details-credit-card-exp-year',
+              name: 'edit-' + commercePaymentDom + '-payment-details-credit-card-owner'
             };
 
             var responseHandler = makeResponseHandler(

--- a/commerce_stripe.module
+++ b/commerce_stripe.module
@@ -22,7 +22,7 @@ function commerce_stripe_libraries_info() {
       'dependencies' => array(),
       'version arguments' => array(
         'file' => 'VERSION',
-        'pattern' => '/(1.\d+(\.\d+)?)/',
+        'pattern' => '/(.*)/',
       ),
       'files' => array(
         'php' => array(
@@ -612,12 +612,23 @@ function commerce_stripe_load_library() {
   }
   else {
     $minimum_version = '1.17.1';
-    if (version_compare($library['version'], $minimum_version) < 0 ) {
-      $message = "Commerce Stripe is currently tested with stripe-php library version @minimum_version. You are using version @installed_version, and you should update.";
-      $variables = array('@minimum_version' => $minimum_version, '@installed_version' => $library['version']);
+    $maximum_version = '1.18.0';
+    $message = "Commerce Stripe is currently tested with stripe-php library versions @minimum_version through @maximum_version. You are using version @installed_version, and you should @upgrade_or_downgrade.";
+
+    //check that it's not lower than the minimum required version
+    if (version_compare($library['version'], $minimum_version, '<')) {
+      $variables = array('@minimum_version' => $minimum_version, '@maximum_version' => $maximum_version, '@installed_version' => $library['version'], '@upgrade_or_downgrade' => 'upgrade');
       watchdog('commerce_stripe', $message, $variables, WATCHDOG_WARNING);
       return FALSE;
     }
+
+    //check that it's not higher than the maximum tested version
+    elseif (version_compare($library['version'], $maximum_version, '>')) {
+      $variables = array('@minimum_version' => $minimum_version, '@maximum_version' => $maximum_version, '@installed_version' => $library['version'], '@upgrade_or_downgrade' => 'downgrade');
+      watchdog('commerce_stripe', $message, $variables, WATCHDOG_WARNING);
+      return FALSE;
+    }
+
     return TRUE;
   }
 }

--- a/commerce_stripe.module
+++ b/commerce_stripe.module
@@ -273,6 +273,9 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
   $transaction->instance_id = $payment_method['instance_id'];
   $transaction->amount = $charge['amount'];
   $transaction->currency_code = $currency_code;
+
+  drupal_alter('commerce_stripe_transaction', $c, $transaction);
+
   try {
     // Stripe does not appreciate $0 transfers.
     if ($charge['amount'] > 0) {

--- a/commerce_stripe.module
+++ b/commerce_stripe.module
@@ -236,13 +236,6 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
   // Begin assembling charge parameters.
   Stripe::setApiKey($payment_method['settings']['secret_key']);
 
-  //check for existence of commerce_marketplace and if so add store # to order
-  if (module_exists('commerce_marketplace_order') && isset($order->commerce_store['und'][0]['target_id'])) {
-    foreach($order->commerce_store['und'] as $key => $value) {
-      $stores .= t('Store Number: @store_number ', array('@store_number' => $value['target_id']));
-    }
-  }
-
   $currency_code = $payment_method['settings']['stripe_currency'];
   if(isset($charge['currency_code'])){
     $currency_code = $charge['currency_code'];
@@ -251,7 +244,7 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
     'amount' => $charge['amount'],
     'currency' => $currency_code,
     'card' => $_POST['stripeToken'],
-    'description' =>  $stores . t('Order Number: @order_number', array('@order_number' => $order->order_number)),
+    'description' => t('Order Number: @order_number', array('@order_number' => $order->order_number)),
   );
 
   // To later store the card with all required fields, carry out necessary steps before making the charge request.
@@ -274,12 +267,19 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
   $transaction->amount = $charge['amount'];
   $transaction->currency_code = $currency_code;
 
-  drupal_alter('commerce_stripe_transaction', $c, $transaction);
+  //The dest parameter can be used to send the charge to a connected stripe account.
+  $context = array(
+    'transaction' => $transaction,
+    'dest' => array(),
+    'payment_method' => $payment_method,
+  );
+
+  drupal_alter('commerce_stripe_transaction', $c, $context);
 
   try {
     // Stripe does not appreciate $0 transfers.
     if ($charge['amount'] > 0) {
-      $response = Stripe_Charge::create($c);
+      $response = isset($context['dest']) ? Stripe_Charge::create($c, $context['dest']) : Stripe_Charge::create($c);
       $transaction->remote_id = $response->id;
       $transaction->payload[REQUEST_TIME] = $response->__toJSON();
       $transaction->message = t('Payment completed successfully.');

--- a/commerce_stripe.module
+++ b/commerce_stripe.module
@@ -216,8 +216,7 @@ function _commerce_stripe_credit_card_field_remove_name($content, $element) {
  */
 function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge) {
   // If instructed to do so, try using the specified card on file.
-  if (module_exists('commerce_cardonfile') && $payment_method['settings']['cardonfile'] &&
-      !empty($pane_values['cardonfile']) && $pane_values['cardonfile'] !== 'new') {
+  if (module_exists('commerce_cardonfile') && $payment_method['settings']['cardonfile'] && !empty($pane_values['cardonfile']) && $pane_values['cardonfile'] !== 'new') {
     $card_data = commerce_cardonfile_load($pane_values['cardonfile']);
     if (empty($card_data) || $card_data->status == 0) {
       drupal_set_message(t('The requested card on file is no longer valid.'), 'error');
@@ -248,8 +247,7 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
   );
 
   // To later store the card with all required fields, carry out necessary steps before making the charge request.
-  if (module_exists('commerce_cardonfile') && !empty($payment_method['settings']['cardonfile']) &&
-      !empty($pane_values['credit_card']['cardonfile_store']) && $pane_values['credit_card']['cardonfile_store']) {
+  if (module_exists('commerce_cardonfile') && !empty($payment_method['settings']['cardonfile']) && !empty($pane_values['credit_card']['cardonfile_store']) && $pane_values['credit_card']['cardonfile_store']) {
     $card = _commerce_stripe_create_card($_POST['stripeToken'], $order->uid, $payment_method);
 
     // If the card is not declined or otherwise is error-free, we can save it.
@@ -654,7 +652,6 @@ function commerce_stripe_customer_id($uid, $instance_id) {
     $card_data = reset($stored_cards);
     list($customer_id, $card_id) = explode('|', $card_data->remote_id);
   }
-
   return !empty($customer_id) ? $customer_id : FALSE;
 }
 

--- a/commerce_stripe.module
+++ b/commerce_stripe.module
@@ -236,6 +236,13 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
   // Begin assembling charge parameters.
   Stripe::setApiKey($payment_method['settings']['secret_key']);
 
+  //check for existence of commerce_marketplace and if so add store # to order
+  if (module_exists('commerce_marketplace_order') && isset($order->commerce_store['und'][0]['target_id'])) {
+    foreach($order->commerce_store['und'] as $key => $value) {
+      $stores .= t('Store Number: @store_number ', array('@store_number' => $value['target_id']));
+    }
+  }
+
   $currency_code = $payment_method['settings']['stripe_currency'];
   if(isset($charge['currency_code'])){
     $currency_code = $charge['currency_code'];
@@ -244,7 +251,7 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
     'amount' => $charge['amount'],
     'currency' => $currency_code,
     'card' => $_POST['stripeToken'],
-    'description' => t('Order Number: @order_number', array('@order_number' => $order->order_number)),
+    'description' =>  $stores . t('Order Number: @order_number', array('@order_number' => $order->order_number)),
   );
 
   // To later store the card with all required fields, carry out necessary steps before making the charge request.

--- a/commerce_stripe.module
+++ b/commerce_stripe.module
@@ -157,7 +157,7 @@ function commerce_stripe_submit_form($payment_method, $pane_values, $checkout_pa
   $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
   $field = field_info_field('commerce_customer_address');
   $instance = field_info_instance('commerce_customer_profile', 'commerce_customer_address', 'billing');
-  
+
   $available_countries = NULL;
   if (isset($form_state['input']['country'])) {
     $available_countries = array($form_state['input']['country'] => NULL);
@@ -217,7 +217,7 @@ function _commerce_stripe_credit_card_field_remove_name($content, $element) {
 function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_values, $order, $charge) {
   // If instructed to do so, try using the specified card on file.
   if (module_exists('commerce_cardonfile') && $payment_method['settings']['cardonfile'] &&
-    !empty($pane_values['cardonfile']) && $pane_values['cardonfile'] !== 'new') {
+      !empty($pane_values['cardonfile']) && $pane_values['cardonfile'] !== 'new') {
     $card_data = commerce_cardonfile_load($pane_values['cardonfile']);
     if (empty($card_data) || $card_data->status == 0) {
       drupal_set_message(t('The requested card on file is no longer valid.'), 'error');
@@ -249,7 +249,7 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
 
   // To later store the card with all required fields, carry out necessary steps before making the charge request.
   if (module_exists('commerce_cardonfile') && !empty($payment_method['settings']['cardonfile']) &&
-    !empty($pane_values['credit_card']['cardonfile_store']) && $pane_values['credit_card']['cardonfile_store']) {
+      !empty($pane_values['credit_card']['cardonfile_store']) && $pane_values['credit_card']['cardonfile_store']) {
     $card = _commerce_stripe_create_card($_POST['stripeToken'], $order->uid, $payment_method);
 
     // If the card is not declined or otherwise is error-free, we can save it.
@@ -274,7 +274,7 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
     'payment_method' => $payment_method,
   );
 
-  drupal_alter('commerce_stripe_transaction', $c, $context);
+  drupal_alter('commerce_stripe_charge', $c, $context);
 
   try {
     // Stripe does not appreciate $0 transfers.
@@ -284,6 +284,7 @@ function commerce_stripe_submit_form_submit($payment_method, $pane_form, $pane_v
       $transaction->payload[REQUEST_TIME] = $response->__toJSON();
       $transaction->message = t('Payment completed successfully.');
       $transaction->status = COMMERCE_PAYMENT_STATUS_SUCCESS;
+      drupal_alter('commerce_stripe_transaction', $transaction, $response);
       commerce_payment_transaction_save($transaction);
       $card_response = $response->card;
     }
@@ -668,7 +669,7 @@ function commerce_stripe_customer_id($uid, $instance_id) {
  */
 function commerce_stripe_field_widget_addressfield_standard_form_alter(&$element, &$form_state, $context) {
   if (!$context['field']['field_name'] == 'commerce_customer_address') {
-      return;
+    return;
   }
   commerce_stripe_set_addressfield_class_names($element);
 }


### PR DESCRIPTION
Hello aviindub,

I've made what I think are a few small changes to Commerce Stripe that open the module up to interactions with other modules via drupal_alter. Adding these drupal_alters can open up Commerce Stripe to other modules without forking.

If you browse the Drupal universe, there are a couple of modules that fork Commerce Stripe and essentially alter the charge parameters passed to Stripe_Charge::create(). (i.e. [Commerce Stripe Connect Field](https://www.drupal.org/sandbox/clevername/2325763)). 

With these two drupal_alters and some changes to the classes in the javascript, I can allow users to connect their own Stripe accounts to their stores and charge them directly, sending an application fee back to the main stripe account. My code is still alpha, but  the changes to Commerce Stripe are solid. Here's my module, [Commerce Marketplace Stripe](https://github.com/glassdimly/commerce_marketplace_stripe), which uses [Commerce Marketplace](https://github.com/maciejzgadzaj/commerce_marketplace). The creator of Marketplace works for Commerce Guys and thus Marketplace likely has a future.

If you are interested, there are a fair number of features that I plan to add as well, including refunds and beefing up Stripe's reporting features. I can work in my own module or contribute them back to Commerce Stripe as you prefer.
